### PR TITLE
Add license headers to python files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# krakenctl
+
+`krakenctl` is a command-line tool for viewing and manipulating running kraken instances.

--- a/argument_manager.py
+++ b/argument_manager.py
@@ -1,3 +1,11 @@
+# argument_manager.py: argument management for krakenctl
+#
+# Author: Kevin Pelzel <kpelzel@lanl.gov>
+#
+# This software is open source software available under the BSD-3 license.
+# Copyright (c) 2021, Triad National Security, LLC
+# See LICENSE file for details.
+
 from enum import Enum
 from typing import List, NewType, Callable, Dict
 import argparse

--- a/krakenctl.py
+++ b/krakenctl.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
 
+# krakenctl.py: cli for viewing and manipulating running kraken instances
+#
+# Author: Kevin Pelzel <kpelzel@lanl.gov>
+#
+# This software is open source software available under the BSD-3 license.
+# Copyright (c) 2021, Triad National Security, LLC
+# See LICENSE file for details.
+
 # from argument_manager import ArgumentManager, OptionalArgument
 from argument_manager import ArgumentManager
 import yaml

--- a/table.py
+++ b/table.py
@@ -1,3 +1,11 @@
+# table.py: table layout methods for krakenctl
+#
+# Author: Kevin Pelzel <kpelzel@lanl.gov>
+#
+# This software is open source software available under the BSD-3 license.
+# Copyright (c) 2021, Triad National Security, LLC
+# See LICENSE file for details.
+
 from rich.console import Console
 from rich.table import Column, Table
 from rich.text import Text


### PR DESCRIPTION
Add a standard license header to each `.py`.  Also put a little one-sentence blurb in readme.

Note: the file descriptions may need to be adjusted.